### PR TITLE
Modify Distribution value from int32 to int64

### DIFF
--- a/gen2-sample/csharp-tsi-gen2-sample/DataPlaneClient/azure-rest-api-specs/specification/timeseriesinsights/data-plane/Microsoft.TimeSeriesInsights/stable/2020-07-31/timeseriesinsights.json
+++ b/gen2-sample/csharp-tsi-gen2-sample/DataPlaneClient/azure-rest-api-specs/specification/timeseriesinsights/data-plane/Microsoft.TimeSeriesInsights/stable/2020-07-31/timeseriesinsights.json
@@ -1051,7 +1051,7 @@
             "description": "Key value pair where key represents the interval denoted by the date time of the start of the interval and the value is the number of events in that interval.",
             "readOnly": true,
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         }
       }


### PR DESCRIPTION
A 32 bit integer might not be sufficient to hold the values returned by the API

related:  https://github.com/Azure-Samples/Azure-Time-Series-Insights/issues/36